### PR TITLE
Start All + unique stream names

### DIFF
--- a/public/components/FFmpegStreamsManager.js
+++ b/public/components/FFmpegStreamsManager.js
@@ -447,19 +447,28 @@ class FFmpegStreamsManager {
 
             await this.loadStreams();
             this.render();
-            if (data.started > 0) {
-                this.afterNextPaint(() => this.showNotification(data.message || `Started ${data.started} streams`, 'success'));
-            }
-            if (data.failed > 0 && data.results && data.results.length > 0) {
+            const hasSuccess = data.started > 0;
+            const hasFailure = data.failed > 0 && data.results && data.results.length > 0;
+            let errorMsg = '';
+            if (hasFailure) {
                 const failed = data.results.filter(r => !r.success);
                 const names = failed.map(r => r.name || r.id).slice(0, 5);
                 const namesText = failed.length > 5 ? `${names.join(', ')} and ${failed.length - 5} more` : names.join(', ');
                 const firstError = failed[0].error ? String(failed[0].error).slice(0, 120) : '';
-                const msg = firstError
+                errorMsg = firstError
                     ? `${data.failed} failed: ${namesText}. First error: ${firstError}${failed[0].error && failed[0].error.length > 120 ? '…' : ''}`
                     : `${data.failed} failed: ${namesText}. Check stream list.`;
-                this.afterNextPaint(() => this.showNotification(msg, 'error'), 150);
             }
+            this.afterNextPaint(() => {
+                if (hasSuccess) {
+                    this.showNotification(data.message || `Started ${data.started} streams`, 'success');
+                    if (hasFailure) {
+                        setTimeout(() => this.showNotification(errorMsg, 'error'), 150);
+                    }
+                } else if (hasFailure) {
+                    this.showNotification(errorMsg, 'error');
+                }
+            });
         } catch (error) {
             console.error('Failed to start all streams:', error);
             this.showNotification(`Failed to start all streams: ${error.message}`, 'error');


### PR DESCRIPTION
Start All button and unique stream name validation.\n\n- **Start All**: Start all stopped/error streams; API \POST /api/streams/start-all\; partial failure toast lists failed names and first error; success then error toasts with 150ms delay.\n- **Unique names**: No duplicate display names (create/update); case-insensitive, trimmed.\n- **UI**: Single Start All / Stop All button; Refresh Devices removed.\n- Tests: integration for start-all response shape; unit for \streamNameExists\.